### PR TITLE
Upgrade Lambda runtime from Python 3.7 to 3.9

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -229,7 +229,7 @@ Resources:
       Properties:
         Description: Copies objects from the S3 bucket to a new location.
         Handler: index.handler
-        Runtime: python3.7
+        Runtime: python3.9
         Role: !GetAtt 'CopyZipsRole.Arn'
         ReservedConcurrentExecutions: 1
         Timeout: 240


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Upgrade Lambda runtime from Python 3.7 to 3.9
I don't want to deploy a new tool with the oldest supported Python Runtime, rather use the latest runtime to ensure the longest lifetime of tool before upgrades are required.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
