### PR TITLE
Updated the CFN Template and Producer Lambda code

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -5,7 +5,7 @@ Parameters:
   ExcludedAccounts:
     Description: Excluded Accounts list. This list should contain Management account, Log Archive and Audit accounts at the minimum
     Default: "['111111111111', '222222222222', '333333333333']"
-    MaxLength: '200'
+    MaxLength: '2000'
     MinLength: '36'
     Type: String
 
@@ -13,6 +13,10 @@ Parameters:
     Description: List of all Config Recorder resource types to enable recording on 
     Default: "AWS::ApiGateway::RestApi,AWS::ApiGateway::Stage,AWS::ApiGatewayV2::Api,AWS::ApiGatewayV2::Stage,AWS::Backup::BackupPlan,AWS::Backup::BackupSelection,AWS::Backup::BackupVault,AWS::Backup::RecoveryPoint,AWS::CloudFormation::Stack,AWS::CloudFront::Distribution,AWS::CloudTrail::Trail,AWS::CloudWatch::Alarm,AWS::CodeBuild::Project,AWS::CodeDeploy::Application,AWS::CodeDeploy::DeploymentConfig,AWS::CodePipeline::Pipeline,AWS::Config::ResourceCompliance,AWS::DynamoDB::Table,AWS::EC2::EIP,AWS::EC2::Instance,AWS::EC2::InternetGateway,AWS::EC2::NetworkAcl,AWS::EC2::NetworkInterface,AWS::EC2::RouteTable,AWS::EC2::SecurityGroup,AWS::EC2::Subnet,AWS::EC2::VPC,AWS::EC2::VPCEndpoint,AWS::EC2::Volume,AWS::ElasticBeanstalk::Application,AWS::ElasticBeanstalk::ApplicationVersion,AWS::ElasticBeanstalk::Environment,AWS::IAM::Policy,AWS::IAM::Role,AWS::IAM::User,AWS::KMS::Key,AWS::Lambda::Function,AWS::RDS::DBSecurityGroup,AWS::RDS::DBSnapshot,AWS::RDS::DBSubnetGroup,AWS::Redshift::ClusterParameterGroup,AWS::S3::AccountPublicAccessBlock,AWS::S3::Bucket,AWS::SNS::Topic,AWS::SQS::Queue,AWS::SSM::ManagedInstanceInventory,AWS::WAFv2::WebACL"
     Type: String
+
+  CloudFormationVersion:
+    Type: String
+    Default: 1
 
 Resources:
     LambdaZipsBucket:
@@ -25,6 +29,7 @@ Resources:
 
     ProducerLambda:
         Type: AWS::Lambda::Function
+        DeletionPolicy: Retain
         Properties:
             #FunctionName: ct_configrecorder_override_producer_cf
             Code:
@@ -46,6 +51,7 @@ Resources:
 
     ProducerLambdaPermissions:                
       Type: AWS::Lambda::Permission
+      DeletionPolicy: Retain
       Properties: 
         Action: 'lambda:InvokeFunction'
         FunctionName: !Ref ProducerLambda
@@ -54,6 +60,7 @@ Resources:
       
     ConsumerLambda:
         Type: AWS::Lambda::Function
+        DeletionPolicy: Retain
         Properties:
             #FunctionName: ct_configrecorder_override_consumer_cf
             Code:
@@ -74,6 +81,7 @@ Resources:
                     
     ConsumerLambdaEventSourceMapping:
         Type: AWS::Lambda::EventSourceMapping
+        DeletionPolicy: Retain
         Properties:
           BatchSize: 1
           Enabled: true
@@ -82,6 +90,7 @@ Resources:
     
     ProducerLambdaExecutionRole:
         Type: 'AWS::IAM::Role'
+        DeletionPolicy: Retain
         Properties:
           ManagedPolicyArns:
             - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
@@ -114,6 +123,7 @@ Resources:
                     
     ConsumerLambdaExecutionRole:
         Type: 'AWS::IAM::Role'
+        DeletionPolicy: Retain
         Properties:
           ManagedPolicyArns:
             - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
@@ -146,9 +156,11 @@ Resources:
 
     SQSConfigRecorder:
         Type: AWS::SQS::Queue
+        DeletionPolicy: Retain
         Properties:
             #QueueName: ct_configrecorder_override_cf
             VisibilityTimeout: 180
+            DelaySeconds: 5
             KmsMasterKeyId: alias/aws/sqs
 
     ProducerEventTrigger:
@@ -173,10 +185,12 @@ Resources:
                     - "Arn"
                 Id: "ProducerTarget"
 
-    FirstDeploymentProducerLambdaTrigger:
-      Type: 'Custom::InvokeLambda'
+    ProducerLambdaTrigger:
+      Type: 'Custom::ExecuteLambda'
       Properties:
         ServiceToken: !GetAtt "ProducerLambda.Arn"
+        FunctionName: !Ref ProducerLambda
+        Version: !Ref CloudFormationVersion
 
     CopyZips:
       Type: Custom::CopyZips


### PR DESCRIPTION
1.	Ability to update the ConfigRecorderResourceTypes and change the Config Recorder resource settings. 
Today to do so, the stack needs to be deleted, and re-created with the updated ConfigRecorderResourceTypes parameters
Fix description : 
template.yaml
•	Deleted the FirstDeploymentProducerLambdaTrigger from the stack
•	Created a new customer resource ProducerLambdaTrigger, which triggers the producer lambda when the stack is created/deleted and when the stack is updated with the change in version number parameter(newly added)
•	Added a DelaySeconds:5 parameter for the SQSConfigRecorder, this is to mitigate the race condition. And ensure the Consumer lambda uses the updated ConfigRecorderResourceTypes parameters
•	Added DeletionPolicy: Retain, for Producer Lambda, Consumer Lambda and its roles, and to SQSConfigRecorder. This is to ensure when we delete the stack, all the messages in the SQS are processed and the configrecorder state is changed to default settings as managed by Control Tower
•	Updated the MaxLength to 2000, to ensure around 150 accounts can be added to ExcludeAccounts parameter. 

ct_configrecorder_override_producer.py
•	Added logic to handle the Update RequestType from the ProducerLambdaTrigger customer resource 

2.	Ability to update the ExcludeAccount parameter. 
The ExcludeAccount parameter was not handing a below specific scenario which customer was looking for. 
	Say the current customization is deployed in customers organization. Cx created a new account using Control Tower Account Factory. By default the customization will be applied to the newly created account. And if the customer wants to exclude the account and remove the customization for the account, they are unable to do so. 
Fix description : 
ct_configrecorder_override_producer.py
•	Added a logic to go through the ExcludeAccount list parameter and change the ConfigRecorder status to the default status for all the accounts in the ExcludeAccount parameter except the root account. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
