### PR TITLE
Addressing security hub finding S3.5

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -26,6 +26,22 @@ Resources:
             ServerSideEncryptionConfiguration:
               - ServerSideEncryptionByDefault:
                   SSEAlgorithm: AES256
+    LambdaZipsBucketPolicy:
+      Type: AWS::S3::BucketPolicy
+      Properties:
+        Bucket:
+          Ref: LambdaZipsBucket
+        PolicyDocument:
+          Statement:
+            - Effect: Deny
+              Action: "s3:*"
+              Principal: "*"
+              Resource:
+                - !Sub 'arn:aws:s3:::${LambdaZipsBucket}'
+                - !Sub 'arn:aws:s3:::${LambdaZipsBucket}/*'
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
 
     ProducerLambda:
         Type: AWS::Lambda::Function


### PR DESCRIPTION
*Issue #, if available:* https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-5

*Description of changes:*
Addressing security hub finding S3.5 which states all S3 buckets should require requests to use Secure Socket Layer. For information on the control here: https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-5



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
