### PR TITLE
Use Service-linked role for Config, and record global resources based on home region

### DIFF
--- a/ct_configrecorder_override_consumer.py
+++ b/ct_configrecorder_override_consumer.py
@@ -85,7 +85,7 @@ def lambda_handler(event, context):
 
         # ControlTower created configuration recorder with name "aws-controltower-BaselineConfigRecorder" and we will update just that
         try:
-            role_arn = 'arn:aws:iam::' + account_id + ':role/aws-controltower-ConfigRecorderRole'
+            role_arn = 'arn:aws:iam::' + account_id + ':role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig'
 
             CONFIG_RECORDER_EXCLUSION_RESOURCE_STRING = os.getenv('CONFIG_RECORDER_EXCLUDED_RESOURCE_LIST')
             CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST = CONFIG_RECORDER_EXCLUSION_RESOURCE_STRING.split(',')
@@ -98,7 +98,7 @@ def lambda_handler(event, context):
                         'roleARN': role_arn,
                         'recordingGroup': {
                             'allSupported': True,
-                            'includeGlobalResourceTypes': False
+                            'includeGlobalResourceTypes': True if os.getenv('CONTROL_TOWER_HOME_REGION') == aws_region else False
                         }
                     })
                 logging.info(f'Response for put_configuration_recorder :{response} ')
@@ -110,7 +110,6 @@ def lambda_handler(event, context):
                         'roleARN': role_arn,
                         'recordingGroup': {
                             'allSupported': False,
-                            'includeGlobalResourceTypes': False,
                             'exclusionByResourceTypes': {
                                 'resourceTypes': CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST
                             },

--- a/template.yaml
+++ b/template.yaml
@@ -210,7 +210,7 @@ Resources:
         #update this to match AWS public bucket
         #s3://marketplace-sa-resources/ct-blogs-content/ct_configrecorder_override_consumer_v2.zip
         #s3://marketplace-sa-resources/ct-blogs-content/ct_configrecorder_override_producer.zip
-        SourceBucket: sb1-sa-resources
+        SourceBucket: marketplace-sa-resources
         Prefix: ct-blogs-content/
         Objects:
           - 'ct_configrecorder_override_producer.zip'
@@ -239,7 +239,7 @@ Resources:
                     - s3:GetObject
                     - s3:GetObjectTagging
                   Resource:
-                    - !Sub 'arn:${AWS::Partition}:s3:::sb1-sa-resources/ct-blogs-content/*'
+                    - !Sub 'arn:${AWS::Partition}:s3:::marketplace-sa-resources/ct-blogs-content/*'
                 - Effect: Allow
                   Action:
                     - s3:PutObject

--- a/template.yaml
+++ b/template.yaml
@@ -13,10 +13,17 @@ Parameters:
     Description: List of all resource types to be excluded from Config Recorder
     Default: "AWS::HealthLake::FHIRDatastore,AWS::Pinpoint::Segment,AWS::Pinpoint::ApplicationSettings"
     Type: String
+  
+  ControlTowerHomeRegion:
+    Type: String
 
   CloudFormationVersion:
     Type: String
     Default: 2
+  
+  PythonRuntimeVersion:
+    Type: String
+    Default: python3.11
 
 Resources:
     LambdaZipsBucket:
@@ -38,7 +45,7 @@ Resources:
                 S3Key: ct-blogs-content/ct_configrecorder_override_producer.zip
             Handler: ct_configrecorder_override_producer.lambda_handler
             Role: !GetAtt ProducerLambdaExecutionRole.Arn
-            Runtime: python3.10
+            Runtime: !Ref PythonRuntimeVersion
             MemorySize: 128
             Timeout: 300
             Architectures:
@@ -70,7 +77,7 @@ Resources:
                 S3Key: ct-blogs-content/ct_configrecorder_override_consumer_v2.zip
             Handler: ct_configrecorder_override_consumer.lambda_handler
             Role: !GetAtt ConsumerLambdaExecutionRole.Arn
-            Runtime: python3.10
+            Runtime: !Ref PythonRuntimeVersion
             MemorySize: 128
             Timeout: 180
             Architectures:
@@ -80,6 +87,7 @@ Resources:
                 Variables:
                     LOG_LEVEL: INFO
                     CONFIG_RECORDER_EXCLUDED_RESOURCE_LIST: !Ref ConfigRecorderExcludedResourceTypes
+                    CONTROL_TOWER_HOME_REGION: !Ref ControlTowerHomeRegion
 
     ConsumerLambdaEventSourceMapping:
         Type: AWS::Lambda::EventSourceMapping
@@ -202,7 +210,7 @@ Resources:
         #update this to match AWS public bucket
         #s3://marketplace-sa-resources/ct-blogs-content/ct_configrecorder_override_consumer_v2.zip
         #s3://marketplace-sa-resources/ct-blogs-content/ct_configrecorder_override_producer.zip
-        SourceBucket: marketplace-sa-resources
+        SourceBucket: sb1-sa-resources
         Prefix: ct-blogs-content/
         Objects:
           - 'ct_configrecorder_override_producer.zip'
@@ -231,7 +239,7 @@ Resources:
                     - s3:GetObject
                     - s3:GetObjectTagging
                   Resource:
-                    - !Sub 'arn:${AWS::Partition}:s3:::marketplace-sa-resources/ct-blogs-content/*'
+                    - !Sub 'arn:${AWS::Partition}:s3:::sb1-sa-resources/ct-blogs-content/*'
                 - Effect: Allow
                   Action:
                     - s3:PutObject
@@ -245,7 +253,7 @@ Resources:
       Properties:
         Description: Copies objects from the S3 bucket to a new location.
         Handler: index.handler
-        Runtime: python3.10
+        Runtime: !Ref PythonRuntimeVersion
         Role: !GetAtt 'CopyZipsRole.Arn'
         ReservedConcurrentExecutions: 1
         Timeout: 300


### PR DESCRIPTION
*Issue #, if available:*
closes https://github.com/aws-samples/aws-control-tower-config-customization/issues/9

*Description of changes:*
1. python3.11 runtime for Lambda
2. Uses the service-linked role `AWSServiceRoleForConfig`
3. Sets the `includeGlobalResourceTypes` boolean based on the region in which the configuration recorder is placed. If it is the Control Tower Landing Zone's home region, the value will be `True`, otherwise `False`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
