### PR TITLE
Add recording frequency setting

### DIFF
--- a/ct_configrecorder_override_consumer.py
+++ b/ct_configrecorder_override_consumer.py
@@ -89,6 +89,7 @@ def lambda_handler(event, context):
 
             CONFIG_RECORDER_EXCLUSION_RESOURCE_STRING = os.getenv('CONFIG_RECORDER_EXCLUDED_RESOURCE_LIST')
             CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST = CONFIG_RECORDER_EXCLUSION_RESOURCE_STRING.split(',')
+            CONFIG_RECORDER_RECORDING_FREQUENCY = os.getenv('CONFIG_RECORDER_RECORDING_FREQUENCY')
 
             # Event = Delete is when stack is deleted, we rollback changed made and leave it as ControlTower Intended
             if event == 'Delete':
@@ -117,6 +118,9 @@ def lambda_handler(event, context):
                             'recordingStrategy': {
                                 'useOnly': 'EXCLUSION_BY_RESOURCE_TYPES'
                             }
+                        },
+                        'recordingMode': {
+                            'recordingFrequency': CONFIG_RECORDER_RECORDING_FREQUENCY
                         }
                     })
                 logging.info(f'Response for put_configuration_recorder :{response} ')

--- a/template.yaml
+++ b/template.yaml
@@ -13,6 +13,14 @@ Parameters:
     Description: List of all resource types to be excluded from Config Recorder
     Default: "AWS::HealthLake::FHIRDatastore,AWS::Pinpoint::Segment,AWS::Pinpoint::ApplicationSettings"
     Type: String
+  
+  ConfigRecorderRecordingFrequency:
+    Description: Frequency of recording configuration changes.
+    Default: CONTINUOUS
+    Type: String
+    AllowedValues:
+      - CONTINUOUS
+      - DAILY
 
   CloudFormationVersion:
     Type: String
@@ -80,6 +88,7 @@ Resources:
                 Variables:
                     LOG_LEVEL: INFO
                     CONFIG_RECORDER_EXCLUDED_RESOURCE_LIST: !Ref ConfigRecorderExcludedResourceTypes
+                    CONFIG_RECORDER_RECORDING_FREQUENCY: !Ref ConfigRecorderRecordingFrequency
 
     ConsumerLambdaEventSourceMapping:
         Type: AWS::Lambda::EventSourceMapping


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-samples/aws-control-tower-config-customization/issues/11

*Description of changes:*

Adding new option of recording frequency of CONTINUOUS and DAILY.
Users of this solution can choose from CONTINUOUS and DAILY in CloudFormation parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
