### PR TITLE
Added the ability to set the recording frequency for individual resources

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -14,6 +14,19 @@ Parameters:
     Default: "AWS::HealthLake::FHIRDatastore,AWS::Pinpoint::Segment,AWS::Pinpoint::ApplicationSettings"
     Type: String
 
+  ConfigRecorderDailyResourceTypes:
+    Description: List of all resource types to be set to a daily cadence
+    Default: "AWS::HealthLake::FHIRDatastore,AWS::Pinpoint::Segment,AWS::Pinpoint::ApplicationSettings"
+    Type: String
+
+  ConfigRecorderRecordingFrequency:
+    Description: Frequency of recording configuration changes.
+    Default: CONTINUOUS
+    Type: String
+    AllowedValues:
+      - CONTINUOUS
+      - DAILY
+
   CloudFormationVersion:
     Type: String
     Default: 2
@@ -27,6 +40,7 @@ Resources:
               - ServerSideEncryptionByDefault:
                   SSEAlgorithm: AES256
 
+
     ProducerLambda:
         Type: AWS::Lambda::Function
         DeletionPolicy: Retain
@@ -38,7 +52,7 @@ Resources:
                 S3Key: ct-blogs-content/ct_configrecorder_override_producer.zip
             Handler: ct_configrecorder_override_producer.lambda_handler
             Role: !GetAtt ProducerLambdaExecutionRole.Arn
-            Runtime: python3.10
+            Runtime: python3.11
             MemorySize: 128
             Timeout: 300
             Architectures:
@@ -70,7 +84,7 @@ Resources:
                 S3Key: ct-blogs-content/ct_configrecorder_override_consumer_v2.zip
             Handler: ct_configrecorder_override_consumer.lambda_handler
             Role: !GetAtt ConsumerLambdaExecutionRole.Arn
-            Runtime: python3.10
+            Runtime: python3.11
             MemorySize: 128
             Timeout: 180
             Architectures:
@@ -79,7 +93,9 @@ Resources:
             Environment:
                 Variables:
                     LOG_LEVEL: INFO
+                    CONFIG_RECORDER_DAILY_RESOURCE_LIST: !Ref ConfigRecorderDailyResourceTypes
                     CONFIG_RECORDER_EXCLUDED_RESOURCE_LIST: !Ref ConfigRecorderExcludedResourceTypes
+                    CONFIG_RECORDER_RECORDING_FREQUENCY: !Ref ConfigRecorderRecordingFrequency
 
     ConsumerLambdaEventSourceMapping:
         Type: AWS::Lambda::EventSourceMapping


### PR DESCRIPTION
Added the ability to set the recording frequency for individual resources. Added error checks for to handle the case where exclusions are empty.

*Issue #, if available:*

https://github.com/aws-samples/aws-control-tower-config-customization/issues/11

*Description of changes:*
* Added a parameter called `ConfigRecorderDailyResourceTypes` which is a list of resources that will switch from continuous recording to daily recording. 
* Added a parameter called `ConfigRecorderRecordingFrequency` which can be CONTINUOUS or DAILY. This changes the record frequency for ALL resources that are not excluded. (built off of @sho-saito's changes in PR #4)
* 
*NOTE* As of today, the default boto3 client used by the python3.12 runtime of Lambda uses boto3 version 1.28.72 which does not include the recordingMode parameter. To use this code, a lambda layer is required to upgrade the boto3 library to a later version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
