### PR TITLE
fix(consumer): Deleting the stack was not reverting `recordingMode` to the original state.

### DIFF
--- a/ct_configrecorder_override_consumer.py
+++ b/ct_configrecorder_override_consumer.py
@@ -107,7 +107,8 @@ def lambda_handler(event, context):
                         'recordingGroup': {
                             'allSupported': True,
                             'includeGlobalResourceTypes': False
-                        }
+                        },
+                        'recordingMode': {'recordingFrequency': 'CONTINUOUS'},
                     })
                 logging.info(f'Response for put_configuration_recorder :{response} ')
 


### PR DESCRIPTION
*Description of changes:*

In my testing, I noticed that when the stack was deleted, the `recordingMode` was not reset to `CONTINUOUS`. This code resolves that issue.
