### PR TITLE
fix(logging): Some log lines were incorrect

### DIFF
--- a/ct_configrecorder_override_consumer.py
+++ b/ct_configrecorder_override_consumer.py
@@ -107,7 +107,8 @@ def lambda_handler(event, context):
                         'recordingGroup': {
                             'allSupported': True,
                             'includeGlobalResourceTypes': False
-                        }
+                        },
+                        'recordingMode': {'recordingFrequency': 'CONTINUOUS'},
                     })
                 logging.info(f'Response for put_configuration_recorder :{response} ')
 

--- a/ct_configrecorder_override_consumer.py
+++ b/ct_configrecorder_override_consumer.py
@@ -80,7 +80,7 @@ def lambda_handler(event, context):
 
         # Describe configuration recorder
         configrecorder = configservice.describe_configuration_recorders()
-        logging.info(f'Existing Configuration Recorder :', configrecorder)
+        logging.info(f'Existing Configuration Recorder: {configrecorder}')
 
         # ControlTower created configuration recorder with name "aws-controltower-BaselineConfigRecorder" and we will update just that
         try:
@@ -110,7 +110,9 @@ def lambda_handler(event, context):
                         },
                         'recordingMode': {'recordingFrequency': 'CONTINUOUS'},
                     })
-                logging.info(f'Response for put_configuration_recorder :{response} ')
+                logging.warn(
+                    f"Configuration Recorder reset to default. Response: {json.dumps(response, default=str)}"
+                )
 
             else:
                 config_recorder = {
@@ -152,7 +154,7 @@ def lambda_handler(event, context):
             logging.info(f'Post Change Configuration recorder : {configrecorder}')
 
         except botocore.exceptions.ClientError as exe:
-            logging.error('Unable to Update Config Recorder for Account and Region : ', account_id, aws_region)
+            logging.error(f'Unable to Update Config Recorder for Account {account_id} and Region {aws_region}')
             configrecorder = configservice.describe_configuration_recorders()
             logging.info(f'Exception : {configrecorder}')
             raise exe

--- a/ct_configrecorder_override_producer.py
+++ b/ct_configrecorder_override_producer.py
@@ -74,7 +74,7 @@ def lambda_handler(event, context):
         elif ('LogicalResourceId' in event) and (event['RequestType'] == 'Update'):
             logging.info('Update Update')
             logging.info(
-                'overriding config recorder for ALL accounts because of first run after function deployment from CloudFormation')
+                'overriding config recorder for ALL accounts because of CloudFormation stack update')
             override_config_recorder(excluded_accounts, sqs_url, '', 'Update')
             response = {}
             update_excluded_accounts(excluded_accounts,sqs_url)
@@ -83,8 +83,8 @@ def lambda_handler(event, context):
             cfnresponse.send(event, context, cfnresponse.SUCCESS, response, "CustomResourcePhysicalID")    
         elif ('LogicalResourceId' in event) and (event['RequestType'] == 'Delete'):
             logging.info('DELETE DELETE')
-            logging.info(
-                'overriding config recorder for ALL accounts because of first run after function deployment from CloudFormation')
+            logging.warn(
+                'Initiating config recorder cleanup for ALL accounts due to CloudFormation stack deletion')
             override_config_recorder(excluded_accounts, sqs_url, '', 'Delete')
             response = {}
             ## Send signal back to CloudFormation after the final run


### PR DESCRIPTION
*Description of changes:*

- Some log lines were supposed to log additional data, but did not.
- Some log lines were copied from another and the contents never changed, thus making them log incorrect information.