### PR TITLE
Use SNS instead of SQS for communication between Producer and Consumer

### DIFF
--- a/ct_configrecorder_override_consumer.py
+++ b/ct_configrecorder_override_consumer.py
@@ -33,7 +33,7 @@ def lambda_handler(event, context):
 
         logging.info(f'Event: {event}')
 
-        body = json.loads(event['Records'][0]['body'])
+        body = json.loads(event['Records'][0]['Sns']['Message'])
         account_id = body['Account']
         aws_region = body['Region']
         event = body['Event']

--- a/template.yaml
+++ b/template.yaml
@@ -58,6 +58,12 @@ Resources:
                 Bool:
                   aws:SecureTransport: false
 
+    SNSConfigRecorderTopic:
+        Type: AWS::SNS::Topic
+        DeletionPolicy: Retain
+        Properties:
+          DisplayName: "Config Recorder Topic"
+
     ProducerLambda:
         Type: AWS::Lambda::Function
         DeletionPolicy: Retain
@@ -78,7 +84,7 @@ Resources:
                 Variables:
                     EXCLUDED_ACCOUNTS: !Ref ExcludedAccounts
                     LOG_LEVEL: INFO
-                    SQS_URL: !Ref SQSConfigRecorder
+                    SNS_TOPIC_ARN: !GetAtt SNSConfigRecorderTopic.TopicArn
 
     ProducerLambdaPermissions:                
       Type: AWS::Lambda::Permission
@@ -111,16 +117,8 @@ Resources:
                     CONFIG_RECORDER_OVERRIDE_DAILY_RESOURCE_LIST: !Ref ConfigRecorderDailyResourceTypes
                     CONFIG_RECORDER_OVERRIDE_EXCLUDED_RESOURCE_LIST: !Ref ConfigRecorderExcludedResourceTypes
                     CONFIG_RECORDER_DEFAULT_RECORDING_FREQUENCY: !Ref ConfigRecorderDefaultRecordingFrequency
+                    SNS_TOPIC_ARN: !GetAtt SNSConfigRecorderTopic.TopicArn
 
-    ConsumerLambdaEventSourceMapping:
-        Type: AWS::Lambda::EventSourceMapping
-        DeletionPolicy: Retain
-        Properties:
-          BatchSize: 1
-          Enabled: true
-          EventSourceArn: !GetAtt SQSConfigRecorder.Arn
-          FunctionName: !GetAtt ConsumerLambda.Arn                
-    
     ProducerLambdaExecutionRole:
         Type: 'AWS::IAM::Role'
         DeletionPolicy: Retain
@@ -148,12 +146,9 @@ Resources:
                     Resource: !Sub 'arn:${AWS::Partition}:cloudformation:*:*:stackset/AWSControlTowerBP-BASELINE-CONFIG:*'
                   - Effect: Allow
                     Action:
-                      - sqs:DeleteMessage
-                      - sqs:ReceiveMessage
-                      - sqs:SendMessage
-                      - sqs:GetQueueAttributes
-                    Resource: !GetAtt SQSConfigRecorder.Arn  
-                    
+                      - sns:Publish
+                    Resource: !GetAtt SNSConfigRecorderTopic.TopicArn
+
     ConsumerLambdaExecutionRole:
         Type: 'AWS::IAM::Role'
         DeletionPolicy: Retain
@@ -181,19 +176,9 @@ Resources:
                     Resource: "*"
                   - Effect: Allow
                     Action:
-                      - sqs:DeleteMessage
-                      - sqs:ReceiveMessage
-                      - sqs:SendMessage
-                      - sqs:GetQueueAttributes
-                    Resource: !GetAtt SQSConfigRecorder.Arn   
-
-    SQSConfigRecorder:
-        Type: AWS::SQS::Queue
-        DeletionPolicy: Retain
-        Properties:
-            VisibilityTimeout: 180
-            DelaySeconds: 5
-            KmsMasterKeyId: alias/aws/sqs
+                      - sns:Subscribe
+                      - sns:Receive
+                    Resource: !Ref SNSConfigRecorderTopic
 
     ProducerEventTrigger:
         Type: AWS::Events::Rule
@@ -207,7 +192,7 @@ Resources:
                             "eventName": ["UpdateLandingZone", "CreateManagedAccount", "UpdateManagedAccount"]
                           }
                         }'
-          Name: !GetAtt SQSConfigRecorder.QueueName 
+          Name: "ConfigRecorderProducerEventTrigger"
           State: ENABLED
           Targets: 
             - 
@@ -325,3 +310,10 @@ Resources:
                 finally:
                     timer.cancel()
                     cfnresponse.send(event, context, status, {}, None)
+
+    ConsumerLambdaSubscription:
+        Type: AWS::SNS::Subscription
+        Properties:
+          Protocol: lambda
+          Endpoint: !GetAtt ConsumerLambda.Arn
+          TopicArn: !GetAtt SNSConfigRecorderTopic.TopicArn


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The Lambda handler was short-polling SQS, which resulted in a very large number of API requests to SQS.

This activity was consuming a significant portion of my free monthly  tier of SQS. I fixed this issue by using SNS instead of SQS.

This change may result in reduced message ordering accuracy (unless we use FIFO queues instead of standard ones). 
Since the events are not triggered frequently, this may not pose any significant issues. The solution has been working well in my environment.

This repository solution has been very helpful in reducing costs. Thanks!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
