### PR TITLE
Use existing AWS Config recorder name to prevent recorder limit exception

### DIFF
--- a/ct_configrecorder_override_consumer.py
+++ b/ct_configrecorder_override_consumer.py
@@ -80,7 +80,13 @@ def lambda_handler(event, context):
 
         # Describe configuration recorder
         configrecorder = configservice.describe_configuration_recorders()
-        logging.info(f'Existing Configuration Recorder :', configrecorder)
+        logging.info(f'Existing Configuration Recorder: {configrecorder}')
+
+        # Get the name of the existing recorder if it exists, otherwise use the default name
+        recorder_name = 'aws-controltower-BaselineConfigRecorder'
+        if configrecorder and 'ConfigurationRecorders' in configrecorder and len(configrecorder['ConfigurationRecorders']) > 0:
+            recorder_name = configrecorder['ConfigurationRecorders'][0]['name']
+            logging.info(f'Using existing recorder name: {recorder_name}')
 
         # ControlTower created configuration recorder with name "aws-controltower-BaselineConfigRecorder" and we will update just that
         try:
@@ -102,7 +108,7 @@ def lambda_handler(event, context):
             if event == 'Delete':
                 response = configservice.put_configuration_recorder(
                     ConfigurationRecorder={
-                        'name': 'aws-controltower-BaselineConfigRecorder',
+                        'name': recorder_name,
                         'roleARN': role_arn,
                         'recordingGroup': {
                             'allSupported': True,
@@ -113,7 +119,7 @@ def lambda_handler(event, context):
 
             else:
                 config_recorder = {
-                    'name': 'aws-controltower-BaselineConfigRecorder',
+                    'name': recorder_name,
                     'roleARN': role_arn,
                     'recordingGroup': {
                         'allSupported': False,


### PR DESCRIPTION
*Issue #, if available:*

The Lambda function was encountering a `MaxNumberOfConfigurationRecordersExceededException` error when trying to update the AWS Config recorder settings. This occurs because AWS Config has a limit of one configuration recorder per account per region.

*Description of changes:*

This PR modifies the consumer Lambda to check for existing configuration recorders and reuse the name of any existing recorder instead of always using the hardcoded default name. This prevents the Lambda from attempting to create a new recorder when one already exists.

* Changes
  * Added logic to retrieve the name of any existing configuration recorder
  * Modified the code to use the retrieved name when updating the recorder configuration
  * Preserved all original functionality while fixing the specific exception



---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
