### PR TITLE
update to allow exclusions and record Global IAM resource-types in the Control Tower Home region only.

### DIFF
--- a/ct_configrecorder_override_consumer.py
+++ b/ct_configrecorder_override_consumer.py
@@ -86,6 +86,9 @@ def lambda_handler(event, context):
         try:
             role_arn = 'arn:aws:iam::' + account_id + ':role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig'
 
+            ## added IAM global resource list
+            GLOBAL_IAM_RESOURCE_LIST = ['AWS::IAM::Group','AWS::IAM::Policy','AWS::IAM::Role','AWS::IAM::User']
+
             CONFIG_RECORDER_DAILY_RESOURCE_STRING = os.getenv('CONFIG_RECORDER_OVERRIDE_DAILY_RESOURCE_LIST')
             CONFIG_RECORDER_OVERRIDE_DAILY_RESOURCE_LIST = CONFIG_RECORDER_DAILY_RESOURCE_STRING.split(
                 ',') if CONFIG_RECORDER_DAILY_RESOURCE_STRING != '' else []
@@ -97,6 +100,18 @@ def lambda_handler(event, context):
             #remove any resource type from daily list that are in exclision list
             res = [x for x in CONFIG_RECORDER_OVERRIDE_DAILY_RESOURCE_LIST if x not in CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST]
             CONFIG_RECORDER_OVERRIDE_DAILY_RESOURCE_LIST[:] = res
+
+            ## create two new lists - NOT_HOME and HOME
+            CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST_NOT_HOME = []
+            CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST_HOME = []
+
+            ## remove any of the global IAM resources from exclusion list for HOME region
+            home = [x for x in CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST if x not in GLOBAL_IAM_RESOURCE_LIST]
+            CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST_HOME[:] = home
+            ## take home list and add globals for NOT_HOME exclusion list for linked regions
+            CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST_NOT_HOME = home + GLOBAL_IAM_RESOURCE_LIST
+
+            home_region = os.getenv('CONTROL_TOWER_HOME_REGION') == aws_region
 
             # Event = Delete is when stack is deleted, we rollback changed made and leave it as ControlTower Intended
             if event == 'Delete':
@@ -119,7 +134,8 @@ def lambda_handler(event, context):
                         'allSupported': False,
                         'includeGlobalResourceTypes': False,
                         'exclusionByResourceTypes': {
-                            'resourceTypes': CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST
+                        ## for exclusion list exclusionByResourceTypes.resourceTypes: if home_region==true use home, else use not_home
+                            'resourceTypes': CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST_HOME if home_region == True else CONFIG_RECORDER_EXCLUSION_RESOURCE_LIST_NOT_HOME
                         },
                         'recordingStrategy': {
                             'useOnly': 'EXCLUSION_BY_RESOURCE_TYPES'

--- a/template.yaml
+++ b/template.yaml
@@ -111,6 +111,7 @@ Resources:
                     CONFIG_RECORDER_OVERRIDE_DAILY_RESOURCE_LIST: !Ref ConfigRecorderDailyResourceTypes
                     CONFIG_RECORDER_OVERRIDE_EXCLUDED_RESOURCE_LIST: !Ref ConfigRecorderExcludedResourceTypes
                     CONFIG_RECORDER_DEFAULT_RECORDING_FREQUENCY: !Ref ConfigRecorderDefaultRecordingFrequency
+                    CONTROL_TOWER_HOME_REGION: !Ref 'AWS::Region'
 
     ConsumerLambdaEventSourceMapping:
         Type: AWS::Lambda::EventSourceMapping


### PR DESCRIPTION
*Issue #, if available:*
How to exclude global resource types #14
https://github.com/aws-samples/aws-control-tower-config-customization/issues/14

*Description of changes:*

1. Added variable to CFN template.yaml to get the Control Tower Home region which is the region that deploys the Config BASELINE StackSet and the solution. Consistent with this commit:
https://github.com/aws-samples/aws-control-tower-config-customization/pull/19/commits/4c4eb774dac2598da76c2f889659416197d229e0

2. Added a static list of the 4 Global IAM resource-types as reference to add and remove to two new lists created.

3. Created two new lists for exclusions: one for resource-types to exclude in the Home region and one for resource-types to exclude for all other CT governed regions, which should contain the 4 Global IAM resource-types.

4. Used a list comprehension to remove or add the 4 Global IAM resource-types accordingly.

5. Confirm if the region is the CT Home region to select the appropriate exclusion list for the recorder in that region.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
