### PR TITLE
Add inclusion/exclusion flexibility for config recording strategies

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -9,9 +9,22 @@ Parameters:
     MinLength: '36'
     Type: String
 
+  ConfigRecorderStrategy:
+    Default: EXCLUSION
+    Description: Config Recorder Strategy
+    Type: String
+    AllowedValues:
+      - EXCLUSION
+      - INCLUSION
+
   ConfigRecorderExcludedResourceTypes:
-    Description: List of all resource types to be excluded from Config Recorder
+    Description: List of all resource types to be excluded from Config Recorder if you pick EXCLUSION strategy
     Default: "AWS::HealthLake::FHIRDatastore,AWS::Pinpoint::Segment,AWS::Pinpoint::ApplicationSettings"
+    Type: String
+
+  ConfigRecorderIncludedResourceTypes:
+    Description: List of all resource types to be included in Config Recorder if you pick INCLUSION strategy
+    Default: "AWS::S3::Bucket,AWS::CloudTrail::Trail"
     Type: String
 
   ConfigRecorderDailyResourceTypes:
@@ -113,9 +126,11 @@ Resources:
             Environment:
                 Variables:
                     LOG_LEVEL: INFO
+                    CONFIG_RECORDER_STRATEGY: !Ref ConfigRecorderStrategy
                     CONFIG_RECORDER_OVERRIDE_DAILY_RESOURCE_LIST: !Ref ConfigRecorderDailyResourceTypes
                     CONFIG_RECORDER_OVERRIDE_DAILY_GLOBAL_RESOURCE_LIST: !Ref ConfigRecorderDailyGlobalResourceTypes
                     CONFIG_RECORDER_OVERRIDE_EXCLUDED_RESOURCE_LIST: !Ref ConfigRecorderExcludedResourceTypes
+                    CONFIG_RECORDER_OVERRIDE_INCLUDED_RESOURCE_LIST: !Ref ConfigRecorderIncludedResourceTypes
                     CONFIG_RECORDER_DEFAULT_RECORDING_FREQUENCY: !Ref ConfigRecorderDefaultRecordingFrequency
                     CONTROL_TOWER_HOME_REGION: !Ref 'AWS::Region'
 


### PR DESCRIPTION
Enhanced solution to support both inclusion and exclusion strategies for AWS Config recorder

- Added _ConfigRecorderIncludedResourceTypes_ parameter for inclusion-based recording
- Maintained existing _ConfigRecorderExcludedResourceTypes_ for exclusion-based recording

Key Changes:

**ct_configrecorder_override_consumer.py**
- Added Strategy Selection
- New CONFIG_RECORDER_STRATEGY environment variable with options: EXCLUSION (default) or INCLUSION
- Maintains backward compatibility with existing exclusion-only behavior
- New CONFIG_RECORDER_OVERRIDE_INCLUDED_RESOURCE_LIST parameter for specifying resources to record
- When using INCLUSION strategy, only specified resource types are recorded
- Enhanced Resource List Management
   - For EXCLUSION: Removes daily resources that are in the exclusion list
   - For INCLUSION: Automatically adds daily resources to the inclusion list to ensure they're recorded

**template.yaml**
- New Parameters Added:
  - _ConfigRecorderStrategy_
  - _ConfigRecorderIncludedResourceTypes_
- Updated Consumer Lambda Environment Variables

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
