### PR TITLE
Deleting the stack was not reverting recordingMode to the original state.

### DIFF
--- a/ct_configrecorder_override_consumer.py
+++ b/ct_configrecorder_override_consumer.py
@@ -136,7 +136,8 @@ def lambda_handler(event, context):
                         'recordingGroup': {
                             'allSupported': True,
                             'includeGlobalResourceTypes': home_region
-                        }
+                        },
+                        'recordingMode': {'recordingFrequency': 'CONTINUOUS'},
                     })
                 logging.info(f'Response for put_configuration_recorder :{response} ')
 


### PR DESCRIPTION
Description of changes:

In my testing, I noticed that when the stack was deleted, the recordingMode was not reset to CONTINUOUS. This code resolves that issue.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
